### PR TITLE
RFC: Docs 2 Electric Boogaloo

### DIFF
--- a/requests-for-comments/2026-08-27-docs-2.0.md
+++ b/requests-for-comments/2026-08-27-docs-2.0.md
@@ -1,0 +1,345 @@
+# Request for comments: Docs 2 Electric Boogaloo – Sarah Sanders
+
+## Problem statement
+
+It's no secret that docs aren't the same anymore. Humans are reading less, and using agents more. This doesn't mean docs are _dead_, we still very much need them as a living product reference. It means: _the shape and purpose of "docs as we know them" has changed._
+
+We have data to back this up! In Q3 2024, a human who landed on `posthog.com/docs` read 3.02 pages before leaving. In Q3 2025 it was 2.86, and today it is **2.12.** We're down 26% year over year.
+
+At the same time, way more people are visiting:
+
+- 87.6K unique visitors to `/docs` in July 2025
+- 151.5K in July 2026
+
+That's +73% visitors for +19% pageviews. More people are arriving to docs, but each one is reading less.
+
+And tutorials are worse: 46K pageviews in March 2025, 23K in July 2026.
+
+### So what do we do?
+
+We're due for a new era of docs. I'm calling this new shape "docs for humans". In my mind, there's:
+
+- **Docs for robots:** Docs as we once knew them, served to agents as references. These are where product knowledge lives, and the purpose is for agents to use them as context.
+- **Docs for humans:** Docs written for humans! Use case guides, tutorials, interactive components, example apps, educational content. These are designed entirely with humans in mind, because humans still _want_ to read and learn, they just don't want to read an info dump of reference material.
+
+So we're building Docs 2.0 for _humans_. But what do humans actually need?
+
+It's not a list of formats, it's a list of _jobs_. Here's a model I am proposing. It's inspired by a bunch of different models out there, but tailored for why I think PostHog users visit docs:
+
+- **1 – Look it up:** _What's that thing called and how do I install something?_. Our reference docs are good at this, and it's the job agents have taken over. That's docs for robots and it's working.
+- **2 – Size it up:** _Is this the right tool for me?_ Someone arrives and is comparing us to Amplitude. They need to see what PostHog does on real data, fast, without committing to a demo.
+- **3 – Get it:** _I don't understand how this thing works._ This is the big one for us and it's getting bigger. Self-driving, context warehouse, signals: these are _new mental models_. Our comprehension is being outpaced by how fast we ship.
+- **4 – Mess around:** _Let me poke at it before I commit._ Low barrier to entry, click things, see what happens. Our current version of this is sign up with the wizard and instrument your app, which is still a huge ask for someone who is still deciding. And it doesn't do much teaching.
+- **5 – Get good:** _I want to be great at this, not just get it working._ The gap between someone who has PostHog installed and someone who is a power user is enormous. Hands-on matters here.
+- **6 – Unbreak it:** _Something is broken and I'm on fire._ No patience, wants the answer, right now. Agents are decent at this, but only if the docs contain the actual failure modes, and ours don't have good coverage here.
+
+We can do the best marketing in the world, but if we don't focus on _teaching_ people – how to use PostHog, why it's important, how to get the most out of the platform – we become a company that innovates and lets our users try to keep up. Even the frontier labs are [hiring](https://job-boards.greenhouse.io/anthropic/jobs/5288959008) and paying _big bucks_ for people to come in and lead user education.
+
+Education is the important word there. **Docs 2.0 is education.** It isn't docs with nicer components and it isn't a content refresh. We build the thing that _actually_ teaches people PostHog in the concrete. Every proposal in this RFC flows from this premise.
+
+Anthropic's postings for their Education team says it better than I can:
+
+> "The gap between what Claude can do and what developers know how to build with it is widening."
+
+Swap Claude for PostHog and that's our problem, word for word. We ship faster than anyone can learn us, self-driving widened the gap instead of closing it, and you cannot reference-doc your way out of a comprehension problem. Anthropic and OpenAI both looked at that gap and staffed a real education function. They're right.
+
+Also, we live in the era of _anything_, yes ANYTHING, is possible. Let's get weird with it and push it as far as we can go.
+
+## Success criteria
+
+Measuring traffic doesn't really work anymore, and existentially, _did it ever_?
+
+Docs pageviews are going to continue falling, and that's fine. If we set "recover docs traffic" as a goal, we're in failure mode. We can watch pages per session as a diagnostic, but it's not our target and not what we should optimize for.
+
+Instead, we measure _did people get better at PostHog?_ Let me explain.
+
+### Did they learn something?
+
+We measure this by:
+
+- **Measure completion, not views.** Every Docs 2.0 shape we ship, we measure how far people get and see exactly where they fall off. Target: 40% completion on anything we ship.
+- **Do they come back for more?** Target: 25% of people who finish a lesson start another one within 30 days.
+- **Ask them.** Embed surveys and feedback forms on pages, but ask questions like "did this teach you something you didn't know?"
+
+### Did it change their behavior?
+
+This is the test we are uniquely able to run, because we have all the data.
+
+- **Did they do the thing?** Finished the feature flags lesson, then shipped a feature flag in their own project within 14 days. We can measure that funnel, we just need to build it.
+- **Product breadth.** How many products/tools does a person use? Learning content should _widen_ that number. This is the closest thing we have to a revenue metric.
+- **Time to competence, not install.** Days from signup to first saved insight, first flag rolled out, first replay watched, etc. Time to install isn't as important anymore with the wizard. We need to measure what happens after.
+- **Support deflection.** Fewer community questions about the things we teach properly. This one is also a backlog signal, because it can inform what we teach next.
+- **Personalization pull.** Once "customize this page for me" ships, what share of logged-in docs readers actually press it? If it's under 10%, we built the wrong thing.
+
+### Out of scope
+
+This project won't cover:
+
+- **Reference docs.** Docs for robots stay as they are, but this means the content itself. We can experiment with information architecture and format changes as needed.
+- **Certifications.** A lot of people do this, but it's a compliance nightmare and proctoring problem. It isn't actually what makes people better at PostHog.
+- **Video.** We have a YouTube team for a reason. Video won't be a primary format here, supporting is fine, just not primary.
+- **Pay-to-play.** We are not going to launch this on an LMS or another type of platform we pay for. We'll build it all in-house.
+
+### Getting it out there
+
+No webinars, don't worry. But I do think we need to collab with community to get the content out there. Events, both in person and online, with the sole purpose of _learning something_ might be a hit. Workshops, book clubs, instrumentation demos, you name it.
+
+If the events team has the capacity, we should partner with them.
+
+## Context
+
+### Data
+
+Humans are reading less per visit. Pages per session on `/docs`, by quarter:
+
+| Quarter | Docs pages per session |
+| --- | --- |
+| Q3 2024 | 3.02 |
+| Q3 2025 | 2.86 |
+| Q1 2026 | 2.61 |
+| Q2 2026 | 2.46 |
+| Q3 2026 | 2.12 |
+
+Agents are reading more. Bot pageviews on `/docs/` and `/tutorials` went from 3.0K in October 2025 to 77.5K in July 2026.
+
+And agents don't send traffic back. Referrers to `/docs` over the last three months:
+
+| Source | Pageviews |
+| --- | --- |
+| Google | 500,247 |
+| ChatGPT | 6,788 |
+| Claude | 1,385 |
+| Perplexity | 950 |
+
+Agents consume our docs but only return about 1.8% of what Google returns. We can't bet on that door, so we gotta meet people at the door they're coming to us from.
+
+Pocket guides did 4K pageviews in their first weeks. It's small, but it's a brand new surface with very little distribution behind it, and it's the format that most looks like Docs 2.0 already.
+
+### What others are doing
+
+Every serious developer platform runs a real education surface, and it's not their docs:
+
+- **Stripe** runs [stripe.training](https://www.stripe.training/page/certifications) with a certification track. The certifications are hands-on coding challenges, and their job posting for [Technical Curriculum Developer](https://stripe.com/jobs/listing/technical-curriculum-developer-training-certification/7521016) describes it as a site that "complements Docs by providing a structured, standardized pathway." They also hire Training Engineers for this team. Again, we aren't doing certifications, but there's something to learn here.
+- **Vercel** has [an academy](https://vercel.com/academy) plus [nextjs.org/learn](https://nextjs.org/learn), which is the canonical "build a real app as the curriculum" format.
+- **MongoDB** has [free skill badges](https://learn.mongodb.com/skills), with video, hands-on labs, and skill checks.
+- **Cloudflare** puts sequenced [learning paths](https://developers.cloudflare.com/learning-paths/) directly inside the docs site.
+- **Anthropic** built [academy.claude.com](https://academy.claude.com/) and are building out an entire Education team, with engineers on it. That's where the quote up top comes from.
+- **OpenAI** is hiring for the same types of roles as Anthropic, scoped to "in-product learning, interactive web experiences, and hands-on labs."
+
+So labs are landing on the same thesis, and it's relevant for us too: _capability is outrunning comprehension_.
+
+### What nobody is doing >:)
+
+This is the fun part. We can make waves here.
+
+**Nobody ships docs that personalize to the reader's own data.** The closest thing to this today is [Stripe's Workbench Shell](https://docs.stripe.com/workbench/shell), which runs real CLI commands against your own sandbox. But this lives in the Dashboard, not docs.
+
+**Nobody has good interactive diagrams in production docs.** I've looked and can't find them. Unless anyone knows of anyone else killing the game here.
+
+Both of these are open, and we should take them.
+
+### Website collab
+
+We'll need to coordinate with the website team. A lot of this is going to require intense web development, and we need a clear split of what the website team owns vs. what Wizard & Docs owns.
+
+My proposal here is: keep working in posthog.com obviously, but work with the website team to develop a new app templates that sits close to the templates we already have (`<Reader />`, `<Wizard />`, `<Explorer />`, etc.).
+
+And we scope the surface area:
+
+- We work with the website team to develop our new templates as needed, see Design section for different formats
+- All new Docs 2.0 components live in one directory, so nothing collides with marketing pages
+- Content stays in MDX in `contents/`, which is where docs and pocket guides already live.
+- New components get registered as global MDX shortcodes the way `CalloutBox` and `Steps` are, and Wizard & Docs owns our own component library.
+- We do a design review with the website team upfront for the new app template, then move to normal PR reviews once that's shipped
+
+## Design
+
+### Docs 2.0 lives inside /docs
+
+I propose the content doesn't go to a separate domain. Why? Reference docs are increasingly consumed by agents and human traffic to them is getting shallower. If we put the human content somewhere else, we have taken the humans who _did_ show up and asked them to leave. Reference pages are still needed in your "_uh oh stuff is broken what do I do_" moments. We add the offer to _learn_ on these pages as an alternative.
+
+More concretely: Every reference page gets a persistent option to choose the human path for the same concept – if there is no human path equivalent yet, we link to the closest one.
+
+Cloudflare is proof that learning paths inside docs can work. Everyone else seems to split their education onto a separate domain and I'd like to avoid that if possible.
+
+### So what does it actually look like?
+
+I'm proposing **a custom template per format**, and I'll mock these properly before anything ships.
+
+That's already how posthog.com works: the site is a desktop-style OS and every page uses one of the app templates (`<Reader />`, `<Explorer />`, `<Inbox />`, `<Wizard />`, etc.).
+
+| Format | Template | Status |
+| --- | --- | --- |
+| Reference docs | `<Reader />` | Shipped, unchanged |
+| Pocket guides | `BookReader` | Shipped |
+| Lessons | `<Lesson />` | New, and the only one we have to build |
+| Personalization | Not a template, but layer over any of them | New |
+
+If every format is its own template, the risk is that moving between them feels like three different websites. So: the templates differ, the chrome persists. One control, living in the shared header bar (`<HeaderBar />` in OSChrome, which ReaderView already uses), on every page no matter which template rendered it:
+
+```
+Session replay  ›  Watching replays
+ 
+[ Reference ][ Guide ][ Lesson ]              [ Customize for me ]
+```
+
+Reference is the page you're already on. Guide jumps to the pocket guide chapter covering the same concept. Lesson jumps to the hands-on version. If one doesn't exist yet it's disabled, or points at the nearest thing that does. Customize for me only appears when you're logged in.
+
+**But what about the side-bar?** The left sidebar stays the product tree it already is. Learning content gets filed under the product it teaches:
+
+```
+Session replay
+  Overview
+  Installation
+  ...reference pages...
+  ──────────────
+  Learn
+    Pocket guide: Session replay
+    Lesson: Find the replay that explains your drop-off
+```
+ 
+If we give learning content its own top-level nav item, we've rebuilt the separate-domain problem inside our own sidebar.
+
+The`<Lesson />` template would be the new one. And it could look something like this:
+
+```
+┌───────────────────────────────────────────────────────┐
+│  Watching replays              Step 3 of 8  ▓▓▓░░░  X │
+├─────────────┬─────────────────────┬───────────────────┤
+│ 1 ✓ Set up  │                     │                   │
+│ 2 ✓ Filter  │   Instructions      │   Live Unter      │
+│ 3 ▸ Watch   │   (MDX)             │   / editor        │
+│ 4   Tag it  │                     │   / terminal      │
+│ 5   ...     │   [ Run ]           │                   │
+└─────────────┴─────────────────────┴───────────────────┘
+```
+
+Left is steps and progress. Middle is instructions. Right is whatever that step declared it needs, which is the configurable bit. Closing a lesson returns you to the docs page you came from, not to some separate learning homepage.
+ 
+**URLs stay under `/docs`.** Reference at `/docs/session-replay/watching-replays`, lesson at `/docs/session-replay/learn/<slug>`. Pocket guides currently live at `/pocket-guides`, so we need to move them under `/docs`.
+
+### The formats
+
+We introduce a few formats:
+
+| | What it is | Jobs it serves | Where we are |
+| --- | --- | --- | --- |
+| **Reference docs** | Look something up | Look it up | Out of scope |
+| **Pocket guides** | Use case guides, narrative style with live components. | Size it up, get it, unbreak it | 5 volumes shipped and more on the way |
+| **Lessons** | You do something – gated steps, validated, hands-on. | Get good | Nothing |
+| **Unter/example apps** | The substrate both are built on. | Mess around | In the repo, not deployed |
+| **Personalization** | Not a format, but a layer over any page. | All of them | Nothing |
+
+#### Pocket guides
+
+These are the closest thing we have to Docs 2.0, and the proof the format works:
+
+- Narrative
+- Illustrated with interactive components instead of screenshots
+- One volume per topic
+
+They carry three of the six jobs: size it up, get it, and we can add unbreak it here too as a "what actually goes wrong" chapter in each volume. We can source the failure-mode content from real issues we solve ourselves everyday.
+
+The plan is more volumes.
+
+#### Lessons
+
+This is a new format, and it serves **get good**. It's what our tutorials should be, but aren't.
+
+The format I like here, and one I come back to time and time again, is Codecademy. I've been a long-time user of Codecademy because their learning environment is unparalleled. It's a configurable module grid where each exercise declares what modules it wants:
+
+- Instructions
+- Editor
+- Terminal
+- Browser output
+- Visual aids
+- File navigator
+
+So we replicate this _vibe_, but build our own shell:
+
+- A lesson is MDX content plus a layout declaration saying which modules it needs. Some lessons need an editor plus a terminal. Some need a reading column and a live Unter component. It's flexible.
+- Steps validate and gate. You hit "Run", we validate, the learner advances. This makes people finish, and we can measure it.
+- Every step emits an event and we can actually measure completion instead of pageviews.
+
+I don't think we need real code execution in v1 of this. That would require a whole execution backend. But we _could_ validate against the reader's actual PostHog project instead of running arbitrary code...
+
+#### Unter
+
+Unter is what all the other formats are made of:
+
+- Pocket guide figures are components made from Unter UI
+- Lessons can validate against it
+- Mock UI component library gets extracted from it
+- Deployed and public, essentially a big playground
+
+### Mock UI is the component library
+
+Instead of screenshots (we will still sometimes need them, this isn't meant to be a replace all situation), docs use live replicas of PostHog UI, built as React components. It's not more work I promise.
+
+Models are really great at producing small, clean replicas from source or a DOM snapshot, _and_ the components are testable in a way PNGs aren't. Plus we get to remove noise instead of cropping around it... the pocket guides already do this and they look really slick.
+
+Plus we can use example apps for interactive figures.
+
+So the plan is:
+
+- Build a small number of core applications (deploy Unter first)
+- Extract UI components from them into a shared library
+- Use that library across all Docs 2.0 content
+
+It's a small set we control.
+
+### Personalized docs/agent-driven pages
+
+This is the one I want BAD and Danilo proved the mechanism works. It looks like this:
+
+- When you're logged in you can read a page as written, OR you can choose _"Customize this page for me."_ The page reloads with your project's actual events, property names, etc. in examples.
+- **Turn this into a tutorial** capability reshapes the page into a hands-on lesson that walks you through doing the task in your own project, validating against your own instrumentation as you go.
+
+_Nobody_ has this.
+
+There's some constraints:
+
+- We need posthog.com and app.posthog.com logins to talk to each other
+- The agent should construct elements from a rigidly declarative schema, so we're not shipping DOM injection. Flagged by Danilo, and he's right
+- It's available for authenticated users only, and it reads project data the user has access to
+- Reference content stays canonical, personalization is a view over the page, not a replace for it
+- The agent-generated page is never what a crawler or other human gets
+
+_I am going to experiment with building a low fidelity version of this next week, and add more content here about how this would look technically._
+
+### Build it all in house
+
+I don't think piece-mealing this with different providers is a good idea. Tying ourselves to an LMS vendor limits how far we can go with this.
+
+Everything will run on posthog.com, in our repo, with our own components.
+
+### Trade-offs
+
+- **In-docs integration vs. its own domain.** Building all of this inside the `/docs` nav means living with the existing nav, templates, etc. But a separate surface would be worse at the actual job.
+- **Live components vs. screenshots.** Mock components cost more upfront, but they're testable for drift.
+- **Validated lessons vs. more lessons.** Prose tutorials are cheaper, but an instrumented lesson is way more effective. We'll ship fewer pieces of content, but they'll have larger impact.
+- **Personalization is risky.** It's the most out there idea here, and I'll tackle it last, that way we ship everything else.
+
+## Sprints
+
+I'm betting on this over one quarter, we go all in. It's also a long-term bet because the format, component library, and example apps are infrastructure we'll be building content on top of for years. This first quarter is about proving the format works, and getting the foundation right.
+
+| Sprint | Duration | What ships |
+| --- | --- | --- |
+| Foundations | 2 weeks | Lesson app template, step-level instrumentation and the events schema, MDX shortcodes, design review with the website team |
+| Deploy Unter fr | 2 weeks | Unter deployed as a live app. Core mock UI components extracted into the shared library |
+| First lessons | 2-3 weeks | 3-5 lessons in the new format, gated and validated, on the highest-traffic docs concepts. Add docs entry points |
+| Failure modes | 1 week | Failure-mode chapters in the pocket guide volumes for the products that generate the most support volume |
+| Personalization | 2-3 weeks | Personalization prototype behind a flag, "customize this page for me" on a handful of pages first, then "turn this into a tutorial", needs a security review |
+| Marketing/socialize it | 2 weeks | Run community events and write a blog post about the whole thing |
+
+## Open questions
+
+- Who should we partner with on the website team? Charles?
+- Who owns the events side with community, and do they have capacity?
+- Work out cost estimates for Unter hosting and personalization LLM spend
+- Execution in browser, or validate against the user's real project?
+- Storybook looks dead???? – revive or drop?
+- Security review for agent-driven pages
+- Do pocket guides move from `/pocket-guides` under `/docs`, or stay put and get linked?
+- What do we do with the existing 170 tutorials?

--- a/requests-for-comments/2026-08-27-docs-2.0.md
+++ b/requests-for-comments/2026-08-27-docs-2.0.md
@@ -115,6 +115,37 @@ Agents consume our docs but only return about 1.8% of what Google returns. We ca
 
 Pocket guides did 4K pageviews in their first weeks. It's small, but it's a brand new surface with very little distribution behind it, and it's the format that most looks like Docs 2.0 already.
 
+### Sales has the same challenges our users do
+
+Thanks @joethreepwood for bringing up this point: sales has the same challenges as our users. Sales has deep product knowledge, but it sits in silos and nothing pulls it together to solve real use-cases.
+
+Some signals worth pointing out:
+
+- Positioning and selling pages built after the offsite went largely unused, because the messaging should be baked into our pages already. This is the same argument I'm making for Docs 2.0 living in `/docs`: content in a silo doesn't get found, even by our own teams.
+- There's no dedicated owner for sales enablement right now, so this issue is only getting deeper.
+
+So we can almost kill two birds with one stone here:
+
+- Write the user-facing version first, informed by what sales is stuck on
+- Then we reframe it all for sales second (if there's still a need to)
+
+The user-facing version is what matters most, but we can repackage that content for sales if needed. We don't need to re-invent content across multiple touchpoints.
+
+After scouring Slack threads, it also revealed a backlog of gaps sales has, and it can tell us what to build first. Most of which are already lined up with my gut intuition:
+
+| Topic | Gap | What to write | Other teams own |
+| --- | --- | --- | --- |
+| Self-driving | Are self-driving PRs worth the cost | Pocket guide chapter on validating self-driving works in your repo/what to watch for | Sales pitches/how to sell this content |
+| Managed warehouse | Row and table level perms, row limits, people confused with managed warehouse vs. data warehouse | Lesson on getting warehouse connected + querying, Pocket guide chapter on managed vs. data warehouse, failure-mode chapter on permissions and row limits | Pricing pages |
+| AIO | "Not a complete solution", LLM cost calculation | Pocket guide chapter on LLM cost tracking and how it works, Failure-mode chapter on custom properties and `distinctId` trap | Competitor positioning |
+| Workflows | No good onboarding, should be standard | Lesson: configure a workflow end to end (could be a good first lesson to build to validate lessons) | |
+
+Sales collateral is literally docs and educational content, we don't have two separate content functions. Sales gets collateral faster this way too, because the hard part (explaining the thing well) is already done.
+
+I used [How to pitch self driving](https://posthog.com/handbook/growth/sales/how-to-pitch-self-driving) to inform how I wrote the self-driving pocket guide. We should be using this type of content to inform how we write other educational content.
+
+There's also the problem of sales knowledge being siloed. I have a pitch for this in Design.
+
 ### What others are doing
 
 Every serious developer platform runs a real education surface, and it's not their docs:
@@ -307,6 +338,22 @@ There's some constraints:
 
 _I am going to experiment with building a low fidelity version of this next week, and add more content here about how this would look technically._
 
+### Knowledge sniffing agent
+
+Trying to source knowledge gaps in sales means I have to manually read threads. The sales team also has to take their content and try to transform it into a format where it won't be siloed. This doesn't scale.
+
+I'm proposing a **custom scout**: you tag @PostHog in a thread, and that thread becomes a draft for educational content.
+
+What it does:
+
+1. Reads the thread, plus anything the thread links to
+2. Works out what kind of gap it is, mapped to our six jobs and formats
+3. Decides the format from that: pocket guide chapter, failure-mode chapter, lesson outline
+4. Writes it as MDX that matches our conventions
+5. Opens a draft PR on posthog.com and replies in-thread with the link, docs is tagged for review. I'd like human reviews here, this is the stuff we shouldn't leave entirely to an agent imo
+
+We can make this reactive AND proactive. The proactive version looks like this: the scout skims approved channels weekly and proposes backlog entries nobody explicitly asked for. These go in a backlog, and we can use something akin to the changelog digests to send Sales a weekly ping saying "hey do you want any of this content published?"
+
 ### Build it all in house
 
 I don't think piece-mealing this with different providers is a good idea. Tying ourselves to an LMS vendor limits how far we can go with this.
@@ -328,7 +375,7 @@ I'm betting on this over one quarter, we go all in. It's also a long-term bet be
 | --- | --- | --- |
 | Foundations | 2 weeks | Lesson app template, step-level instrumentation and the events schema, MDX shortcodes, design review with the website team |
 | Deploy Unter fr | 2 weeks | Unter deployed as a live app. Core mock UI components extracted into the shared library |
-| First lessons | 2-3 weeks | 3-5 lessons in the new format, gated and validated, on the highest-traffic docs concepts. Add docs entry points |
+| First lessons | 2-3 weeks | 3-5 lessons in the new format, gated and validated. Topics come from the sales-informed backlog above, starting with workflows because it's the lowest lift |
 | Failure modes | 1 week | Failure-mode chapters in the pocket guide volumes for the products that generate the most support volume |
 | Personalization | 2-3 weeks | Personalization prototype behind a flag, "customize this page for me" on a handful of pages first, then "turn this into a tutorial", needs a security review |
 | Marketing/socialize it | 2 weeks | Run community events and write a blog post about the whole thing |


### PR DESCRIPTION
## Summary

It's time to bring docs to 2030. The time is now:

> "The gap between what [PostHog] can do and what developers know how to build with it is widening." – someone on Anthropic's HR team

## Checklist

- [x] I have considered whether this RFC should instead be private, and confirmed it's appropriate for this public repo. (See the README — this repo is for non-product discussions that are safe to have in public. If the topic touches anything customer-sensitive, commercially sensitive, or otherwise non-public, it likely belongs in a private venue instead.)
